### PR TITLE
feat: Add feature to customize Scylla CDC start time

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/Worker.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/Worker.java
@@ -76,7 +76,9 @@ public final class Worker {
         for (TableName tableName : tableNames) {
             Optional<Long> ttl = workerConfiguration.cql.fetchTableTTL(tableName).get();
             Date minimumWindowStart = new Date(0);
-            if (ttl.isPresent()) {
+            if(workerConfiguration.customMinimumWindowStart > 0) {
+                minimumWindowStart = new Date(now.getTime() - workerConfiguration.customMinimumWindowStart);
+            } else if (ttl.isPresent()) {
                 minimumWindowStart = new Date(now.getTime() - 1000L * ttl.get()); // TTL is in seconds, getTime() in milliseconds
             }
             minimumWindowStarts.put(tableName, new Timestamp(minimumWindowStart));

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/WorkerConfiguration.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/WorkerConfiguration.java
@@ -15,6 +15,7 @@ public final class WorkerConfiguration {
     public static final long DEFAULT_CONFIDENCE_WINDOW_SIZE_MS = 30000;
     public static final RetryBackoff DEFAULT_WORKER_RETRY_BACKOFF =
             new ExponentialRetryBackoffWithJitter(10, 30000);
+    public static final long DEFAULT_CUSTOM_MINIMUM_WINDOW_START = 0;
 
     public final WorkerTransport transport;
     public final WorkerCQL cql;
@@ -23,6 +24,8 @@ public final class WorkerConfiguration {
     public final long queryTimeWindowSizeMs;
     public final long confidenceWindowSizeMs;
 
+    public final long customMinimumWindowStart;
+
     public final RetryBackoff workerRetryBackoff;
 
     private final ScheduledExecutorService executorService;
@@ -30,7 +33,7 @@ public final class WorkerConfiguration {
     private final Clock clock;
     
     private WorkerConfiguration(WorkerTransport transport, WorkerCQL cql, Consumer consumer, long queryTimeWindowSizeMs,
-            long confidenceWindowSizeMs, RetryBackoff workerRetryBackoff, ScheduledExecutorService executorService, Clock clock) {
+            long confidenceWindowSizeMs, RetryBackoff workerRetryBackoff, ScheduledExecutorService executorService, Clock clock, long customMinimumWindowStart) {
         this.transport = Preconditions.checkNotNull(transport);
         this.cql = Preconditions.checkNotNull(cql);
         this.consumer = Preconditions.checkNotNull(consumer);
@@ -41,6 +44,7 @@ public final class WorkerConfiguration {
         this.workerRetryBackoff = Preconditions.checkNotNull(workerRetryBackoff);
         this.executorService = executorService;
         this.clock = Preconditions.checkNotNull(clock);
+        this.customMinimumWindowStart = customMinimumWindowStart;
     }
     
     public ScheduledExecutorService getExecutorService() {
@@ -70,6 +74,8 @@ public final class WorkerConfiguration {
 
         private long queryTimeWindowSizeMs = DEFAULT_QUERY_TIME_WINDOW_SIZE_MS;
         private long confidenceWindowSizeMs = DEFAULT_CONFIDENCE_WINDOW_SIZE_MS;
+
+        private long customMinimumWindowStart = DEFAULT_CUSTOM_MINIMUM_WINDOW_START;
 
         private RetryBackoff workerRetryBackoff = DEFAULT_WORKER_RETRY_BACKOFF;
 
@@ -115,6 +121,11 @@ public final class WorkerConfiguration {
         public Builder withConfidenceWindowSizeMs(long confidenceWindowSizeMs) {
             Preconditions.checkArgument(confidenceWindowSizeMs > 0);
             this.confidenceWindowSizeMs = confidenceWindowSizeMs;
+            return this;
+        }
+
+        public Builder withCustomMinimumWindowStart(long customMinimumWindowStart) {
+            this.customMinimumWindowStart = customMinimumWindowStart;
             return this;
         }
 


### PR DESCRIPTION
Introduced a new feature that allows customization of the start time for the Scylla CDC Kafka connector. Previously, the connector always began reading from the start of the TTL. With this update, users can now specify a custom start time, such as reading from the last 60 seconds. This improves flexibility for real-time streaming scenarios.